### PR TITLE
Fix hightlighting integers in identifiers

### DIFF
--- a/syntax/decaf.vim
+++ b/syntax/decaf.vim
@@ -15,20 +15,21 @@ syn keyword decafStatement def if else while return continue break
 syn keyword decafTodo contained TODO
 syn match decafComment '//.*$' contains=decafTodo
 
-" Literals
-syn match decafConstant 'true\|false\|\d\+'
+" Literals & Constants
+syn keyword decafBoolean true false
+syn match decafIntConstant '\<\d\+\>'
 
 " Strings
 " Match \n, etc in a string
 syn match decafSpecialChar contained "\\\([4-9]\d\|[0-3]\d\d\|[\"\\'ntbrf]\|u\x\{4\}\)"
 syn region decafString start=+"+ end=+"+ end=+$+ contains=decafSpecialChar
 
-
 let b:current_syntax="decaf"
 
 hi def link decafType           Type
 hi def link decafStatement      Statement
-hi def link decafConstant       Constant
+hi def link decafBoolean        Constant
+hi def link decafIntConstant    Constant
 hi def link decafTodo           Todo
 hi def link decafString         String
 hi def link decafSpecialChar    SpecialChar

--- a/test.decaf
+++ b/test.decaf
@@ -11,6 +11,9 @@ def int main() {
 
     int a = 0x12310;
     bool b = false;
+    int test123 = 123;
+    bool falsest = false;
+    bool truest = true;
     print_str("adsada\n");
     return;
 }


### PR DESCRIPTION
Integers should not be highlighted as constants if they are part of an
identifier. For example the 123 in `test123` should not be highlighted
as if it was an integer constant. Likewise, the `true` in `testtruetest`
should not be highlighted.