### PR TITLE
Fix integer constant matching

### DIFF
--- a/syntax/decaf.vim
+++ b/syntax/decaf.vim
@@ -17,7 +17,8 @@ syn match decafComment '//.*$' contains=decafTodo
 
 " Literals & Constants
 syn keyword decafBoolean true false
-syn match decafIntConstant '\<\d\+\>'
+syn match decafDecIntConstant '\<\(0\|[1-9]\d*\)\>'
+syn match decafHexIntConstant '\<0x\(0\|[1-9a-fA-F][0-9a-fA-F]*\)\>'
 
 " Strings
 " Match \n, etc in a string
@@ -29,7 +30,8 @@ let b:current_syntax="decaf"
 hi def link decafType           Type
 hi def link decafStatement      Statement
 hi def link decafBoolean        Constant
-hi def link decafIntConstant    Constant
+hi def link decafDecIntConstant Constant
+hi def link decafHexIntConstant Constant
 hi def link decafTodo           Todo
 hi def link decafString         String
 hi def link decafSpecialChar    SpecialChar

--- a/test.decaf
+++ b/test.decaf
@@ -1,21 +1,21 @@
-//comment TODO
+//comment TODO             // TODO should be one color, the rest should be another
 
-def int main() {
-    while (true) {
-        if (false) {
-            break;
-        } else {
-            continue;
+def int main() {           // def and int should both be highlighted
+    while (true) {         // while and true should both be highlighted
+        if (false) {       // if and false should both be highlight
+            break;         // break should be highlighted
+        } else {           // else should be highlighted
+            continue;      // continue should be highlighted
         }
     }
 
-    int a = 0x12310;
-    bool b = false;
-    int test123 = 123;
-    bool falsest = false;
-    bool truest = true;
-    int dec_bad = 013; // This literal should not be highlighted
-    int hex_bad = 0x013; // This literal should not be highlighted
-    print_str("adsada\n");
-    return;
+    int a = 0x12310;       // int and the constant should be highlighted
+    bool b = false;        // bool and false should be highlighted
+    int test123 = 123;     // int and the constant should be highlighted
+    bool falsest = false;  // bool and false should be highlighted
+    bool truest = true;    // bool and true should be highlighted
+    int dec_bad = 013;     // This literal should not be highlighted
+    int hex_bad = 0x013;   // This literal should not be highlighted
+    print_str("adsada\n"); // The string and \n should be different colors
+    return;                // return should be highlighted
 }

--- a/test.decaf
+++ b/test.decaf
@@ -14,6 +14,8 @@ def int main() {
     int test123 = 123;
     bool falsest = false;
     bool truest = true;
+    int dec_bad = 013; // This literal should not be highlighted
+    int hex_bad = 0x013; // This literal should not be highlighted
     print_str("adsada\n");
     return;
 }


### PR DESCRIPTION
Add support for matching hexadecimal integer constants. Additionally, in
Decaf, neither decimal nor hexadecimal integers may have leading zeros
so those should not be matched as constants.